### PR TITLE
Handle ALL eth interfaces!

### DIFF
--- a/packer_templates/ubuntu/scripts/networking.sh
+++ b/packer_templates/ubuntu/scripts/networking.sh
@@ -10,6 +10,8 @@ network:
   version: 2
   ethernets:
     eth0:
+      match:
+        name: eth*
       dhcp4: true
 EOF
 else


### PR DESCRIPTION
### Description

Configures all `eth*` interfaces w/ DHCP; otherwise, it seems the ordering with which Virtualbox finds interfaces (which may vary) can cause the basebox to timeout, since the NAT interface fails to get an IP.
